### PR TITLE
Simple server when missing Engine key

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,22 +1,32 @@
 // @flow
 
+import http from 'http';
 import { ApolloEngine } from 'apollo-engine';
 import app from './graphqlServer';
 
 require('dotenv').config();
 
 const port = process.env.PORT || 3000;
-const engine = new ApolloEngine({
-  apiKey: String(process.env.ENGINE_KEY),
-});
 
-engine.listen({
-  port,
-  expressApp: app,
-  graphqlPaths: ['/'],
-  frontend: {
-    extensions: {
-      strip: ['tracing'],
+if (process.env.ENGINE_KEY) {
+  const engine = new ApolloEngine({
+    apiKey: String(process.env.ENGINE_KEY),
+  });
+
+  engine.listen({
+    port,
+    expressApp: app,
+    graphqlPaths: ['/'],
+    frontend: {
+      extensions: {
+        strip: ['tracing'],
+      },
     },
-  },
-});
+  });
+} else {
+  // no ENGINE_KEY, start simple server
+  http.createServer(app).listen(
+    port.toString(),
+    () => console.log(`Server is running on port ${port}`), // eslint-disable-line no-console
+  );
+}


### PR DESCRIPTION
When Apollo Engine key is not set, console is full of:
```
ERRO[0255] Error reporting stats. error="invalid API key. You can get one at https://engine.apollographql.com"
```