### PR TITLE
Change roomsize 0 to return null

### DIFF
--- a/src/hotel/dataloaders/HotelRoomsSanitizer.js
+++ b/src/hotel/dataloaders/HotelRoomsSanitizer.js
@@ -17,6 +17,8 @@ export default (rooms: Object, hotelId: number): HotelRoomType[] => {
       },
     ],
     photos: sanitizePhotos(room.room_photos),
-    roomSize: room.room_info.room_size.metre_square,
+    // Some hotels return metre_square: 0, we change this to null instead
+    // so we can handle this as an error on frontend.
+    roomSize: room.room_info.room_size.metre_square || null,
   }));
 };


### PR DESCRIPTION
Some hotels like `Courtyard by Marriott Brno` returns roomSize = 0; We change this to null so we can handle differently in the app.