### PR TITLE
Build: always delete old build files before new build

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -3,6 +3,7 @@
 # see: https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html
 set -e # exit immediately if a pipeline returns a non-zero status
 
+rm -rf .build/
 yarn run babel config --out-dir .build/config --ignore __tests__,__mocks__
 yarn run babel src --out-dir .build/src --ignore __tests__,__mocks__
 # TODO: install only production dependencies (Docker)


### PR DESCRIPTION
Babel will transpile and overwrite old files but it will not delete old files (old code or test files in my case).

This fixes my failing tests issue discovered during JSWeekend.