### PR TITLE
Jest: remove 'logHeapUsage' option from the config file

### DIFF
--- a/jest.json
+++ b/jest.json
@@ -16,6 +16,5 @@
       "statements": 80
     }
   },
-  "logHeapUsage": true,
   "verbose": false
 }


### PR DESCRIPTION
Option 'logHeapUsage' is not valid in the config file - see: https://facebook.github.io/jest/docs/en/configuration.html