### PR TITLE
Add new "FAQCategory" query that enables fetching just a single category

### DIFF
--- a/scripts/graphql-schema-snapshot.json
+++ b/scripts/graphql-schema-snapshot.json
@@ -773,7 +773,44 @@
             ],
             "type": {
               "kind": "OBJECT",
-              "name": "AllFAQCategoriesConnection",
+              "name": "FAQCategoryConnection",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "FAQCategory",
+            "description": "Retrieve specific FAQ category and its subcategories & articles.",
+            "args": [
+              {
+                "name": "id",
+                "description": "ID of FAQ category to retrieve.",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "language",
+                "description": "Language in which the titles and perexes of FAQ categories are returned.",
+                "type": {
+                  "kind": "ENUM",
+                  "name": "Language",
+                  "ofType": null
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "FAQCategory",
               "ofType": null
             },
             "isDeprecated": false,
@@ -6853,7 +6890,7 @@
       },
       {
         "kind": "OBJECT",
-        "name": "AllFAQCategoriesConnection",
+        "name": "FAQCategoryConnection",
         "description": "A connection to a list of items.",
         "fields": [
           {
@@ -6881,7 +6918,7 @@
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
-                "name": "AllFAQCategoriesEdge",
+                "name": "FAQCategoryEdge",
                 "ofType": null
               }
             },
@@ -6896,7 +6933,7 @@
       },
       {
         "kind": "OBJECT",
-        "name": "AllFAQCategoriesEdge",
+        "name": "FAQCategoryEdge",
         "description": "An edge in a connection.",
         "fields": [
           {
@@ -6905,7 +6942,7 @@
             "args": [],
             "type": {
               "kind": "OBJECT",
-              "name": "AllFAQCategories",
+              "name": "FAQCategory",
               "ofType": null
             },
             "isDeprecated": false,
@@ -6935,7 +6972,7 @@
       },
       {
         "kind": "OBJECT",
-        "name": "AllFAQCategories",
+        "name": "FAQCategory",
         "description": null,
         "fields": [
           {
@@ -6975,7 +7012,7 @@
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
-                "name": "AllFAQCategories",
+                "name": "FAQCategory",
                 "ofType": null
               }
             },

--- a/src/FAQ/queries/FAQCategory.js
+++ b/src/FAQ/queries/FAQCategory.js
@@ -1,0 +1,67 @@
+// @flow
+
+import { GraphQLID, GraphQLNonNull } from 'graphql';
+import { fromGlobalId } from 'graphql-relay';
+
+import type { GraphqlContextType } from '../../common/services/GraphqlContext';
+import FAQCategory, {
+  type FAQCategoryType,
+} from '../types/outputs/FAQCategory';
+import LanguageInput from '../../common/types/inputs/LanguageInput';
+
+const findCategory = (
+  categories: FAQCategoryType[],
+  categoryId: number,
+): FAQCategoryType | null => {
+  const parentCategory = categories.find(c => c.id === categoryId);
+
+  if (parentCategory) {
+    return parentCategory;
+  }
+
+  for (const category of categories) {
+    const subcategories = category.subcategories || [];
+    const subcategory = findCategory(subcategories, categoryId);
+
+    if (subcategory) {
+      return subcategory;
+    }
+  }
+
+  return null;
+};
+
+export default {
+  type: FAQCategory,
+  description:
+    'Retrieve specific FAQ category and its subcategories & articles.',
+  args: {
+    id: {
+      type: new GraphQLNonNull(GraphQLID),
+      description: 'ID of FAQ category to retrieve.',
+    },
+    language: {
+      type: LanguageInput,
+      description:
+        'Language in which the titles and perexes of FAQ categories are returned.',
+    },
+  },
+  resolve: async (
+    ancestor: mixed,
+    { language, id }: Object,
+    { dataLoader }: GraphqlContextType,
+  ) => {
+    const categoryId = Number(fromGlobalId(id).id);
+    const categories = await dataLoader.FAQCategories.load({
+      language,
+    });
+
+    const category = findCategory(categories, categoryId);
+
+    if (!category) {
+      throw new Error(`No FAQ category found with ID ${id}`);
+    }
+
+    return category;
+  },
+};

--- a/src/FAQ/queries/__test__/FAQCategory.test.js
+++ b/src/FAQ/queries/__test__/FAQCategory.test.js
@@ -1,0 +1,44 @@
+// @flow
+
+import { graphql, RestApiMock } from '../../../common/services/TestingTools';
+import rootCategory from '../../datasets/rootCategory.json';
+import categories from '../../datasets/categories.json';
+
+describe('allFAQCategories', () => {
+  beforeEach(() => {
+    RestApiMock.onGet(
+      'https://api.skypicker.com/knowledgebase/api/v1/categories',
+    ).replyWithData(rootCategory);
+    RestApiMock.onGet(
+      'https://api.skypicker.com/knowledgebase/api/v1/categories/1',
+    ).replyWithData(categories);
+  });
+
+  it('should return single FAQ category', async () => {
+    const id = 'RkFRQ2F0ZWdvcnk6NDc=';
+    const resultsQuery = `query FAQSubcategories($id: ID!) { 
+      FAQCategory(language: en, id: $id) {
+        id
+        title
+        subcategories {
+          id
+        }
+        FAQs {
+          id
+          title
+        }  
+      }      
+    }`;
+    expect(await graphql(resultsQuery, { id })).toMatchSnapshot();
+  });
+
+  it('should return error for non-existing category', async () => {
+    const id = 'RkFRQ2F0ZWdvcnk6NjY2'; // non-existing category #666
+    const resultsQuery = `query FAQSubcategories($id: ID!) { 
+      FAQCategory(language: en, id: $id) {
+        id
+      }        
+    }`;
+    expect(await graphql(resultsQuery, { id })).toMatchSnapshot();
+  });
+});

--- a/src/FAQ/queries/__test__/__snapshots__/FAQCategory.test.js.snap
+++ b/src/FAQ/queries/__test__/__snapshots__/FAQCategory.test.js.snap
@@ -1,0 +1,56 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`allFAQCategories should return error for non-existing category 1`] = `
+Object {
+  "data": Object {
+    "FAQCategory": null,
+  },
+  "errors": Array [
+    [GraphQLError: No FAQ category found with ID RkFRQ2F0ZWdvcnk6NjY2],
+  ],
+}
+`;
+
+exports[`allFAQCategories should return single FAQ category 1`] = `
+Object {
+  "data": Object {
+    "FAQCategory": Object {
+      "FAQs": Array [
+        Object {
+          "id": "RkFRQXJ0aWNsZToxMzI=",
+          "title": "How do I Refer a Friend?",
+        },
+        Object {
+          "id": "RkFRQXJ0aWNsZTozOQ==",
+          "title": "How do I know which terminals I will be using?",
+        },
+      ],
+      "id": "RkFRQ2F0ZWdvcnk6NDc=",
+      "subcategories": Array [
+        Object {
+          "id": "RkFRQ2F0ZWdvcnk6Mzc=",
+        },
+        Object {
+          "id": "RkFRQ2F0ZWdvcnk6NDA=",
+        },
+        Object {
+          "id": "RkFRQ2F0ZWdvcnk6MzU=",
+        },
+        Object {
+          "id": "RkFRQ2F0ZWdvcnk6MzY=",
+        },
+        Object {
+          "id": "RkFRQ2F0ZWdvcnk6MjY=",
+        },
+        Object {
+          "id": "RkFRQ2F0ZWdvcnk6MzE=",
+        },
+        Object {
+          "id": "RkFRQ2F0ZWdvcnk6NDI=",
+        },
+      ],
+      "title": "Before the flight",
+    },
+  },
+}
+`;

--- a/src/FAQ/types/outputs/FAQCategory.js
+++ b/src/FAQ/types/outputs/FAQCategory.js
@@ -12,7 +12,7 @@ export type FAQCategoryType = {|
 |};
 
 const FAQCategory = new GraphQLObjectType({
-  name: 'AllFAQCategories',
+  name: 'FAQCategory',
   fields: () => ({
     id: globalIdField('FAQCategory', ({ id }: FAQCategoryType) => String(id)),
     title: {

--- a/src/RootQuery.js
+++ b/src/RootQuery.js
@@ -15,6 +15,7 @@ import Hotel from './hotel/queries/Hotel';
 import HotelCities from './hotel/queries/HotelCities';
 import AllFAQs from './FAQ/queries/AllFAQs';
 import AllFAQCategories from './FAQ/queries/AllFAQCategories';
+import FAQCategories from './FAQ/queries/FAQCategory';
 
 export default new GraphQLObjectType({
   name: 'RootQuery',
@@ -33,5 +34,6 @@ export default new GraphQLObjectType({
     hotelCities: HotelCities,
     allFAQs: AllFAQs,
     allFAQCategories: AllFAQCategories,
+    FAQCategory: FAQCategories,
   },
 });


### PR DESCRIPTION
Ok, this is what I really wanted... 🙂 

Changes:
- new `FAQCategory` query to fetch just single FAQ category, possibly with its subcategories and articles
- mischievously doing breaking change - type name `AllFAQCategories` changed to `FAQCategory` because the previous naming was just bad. This should keep consistency with `HotelCity`, `Location` etc. as well.