### PR TITLE
Tests: remove coverage reporting and coverage thresholds

### DIFF
--- a/jest.json
+++ b/jest.json
@@ -4,17 +4,6 @@
     "src/**.js"
   ],
   "coverageReporters": [
-    "lcov",
-    "text",
     "text-summary"
-  ],
-  "coverageThreshold": {
-    "global": {
-      "branches": 80,
-      "functions": 80,
-      "lines": 80,
-      "statements": 80
-    }
-  },
-  "verbose": false
+  ]
 }


### PR DESCRIPTION
It leads to writing stupid snapshot tests or tests just to be OK with the coverage thresholds. I believe that better technique is to write tests when it actually makes sense (units for non-trivial logic and integrations for business critical things).