### PR TITLE
Bookings: use dataloader to fetch all bookings

### DIFF
--- a/src/booking/dataloaders/Booking.js
+++ b/src/booking/dataloaders/Booking.js
@@ -8,6 +8,13 @@ import { sanitizeDetail } from './ApiSanitizer';
 import type { Booking } from '../Booking';
 import type BookingsLoader from './Bookings';
 
+/**
+ * This data loader loads single booking based on it's ID. It does it by calling
+ * the main "Bookings" data loader, extracting so called "simple token" and
+ * returning back the data. This is necessary because "Bookings" data loader
+ * does not return everything necessary. This workaround should nto be needed
+ * with the new Mambo endpoints.
+ */
 export default function createInstance(
   accessToken: ?string,
   bookingsLoader: BookingsLoader,


### PR DESCRIPTION
We used some kind of weird memoization but it didn't work anyway. This fix will send only one request when sending queries like this one:

```graphql
query ManageMyBooking {
  future: customerBookings(only: FUTURE) {
    edges {
      node {
        destinationImageUrl
      }
    }
  }
  past: customerBookings(only: PAST) {
    edges {
      node {
        destinationImageUrl
      }
    }
  }
}
```

We are currently sending 2 requests for this and backend for some reason returns error code for it. This issue should be therefore fixed as well (hopefully).