### PR TITLE
Add 'extensions' to the errors response

### DIFF
--- a/src/FAQ/mutations/addFAQArticleComment.js
+++ b/src/FAQ/mutations/addFAQArticleComment.js
@@ -97,7 +97,7 @@ export default {
     if (response.message !== successfulResponse.message) {
       throw new ProxiedError(
         response.message ? response.message : 'Article commenting failed',
-        response.error_code ? response.error_code : 0,
+        response.error_code ? response.error_code : '-1',
         config.restApiEndpoint.FAQArticleComment(originalId),
       );
     }

--- a/src/common/services/__tests__/HttpRequest.test.js
+++ b/src/common/services/__tests__/HttpRequest.test.js
@@ -40,19 +40,14 @@ describe('GET request in production', () => {
   });
 
   it('throws exception during invalid return status code', async () => {
-    expect.assertions(4);
+    expect.assertions(3);
 
     try {
       await get('https://path/to/api?status=500');
     } catch (error) {
-      // $FlowExpectedError: toBeInstanceOf expects classes but ProxiedError is a function
       expect(error).toBeInstanceOf(ProxiedError);
-      expect(error).toHaveProperty('message', 'Status Text');
-      expect(error).toHaveProperty('originStatusCode', 500);
-      expect(error).toHaveProperty(
-        'originUrl',
-        'https://path/to/api?status=500',
-      );
+      expect(error.message).toBe('Status Text');
+      expect(error.extensions).toMatchSnapshot();
     }
   });
 
@@ -73,19 +68,14 @@ describe('POST request', () => {
 
 describe('POST request in production', () => {
   it('throws exception during invalid return status code', async () => {
-    expect.assertions(4);
+    expect.assertions(3);
 
     try {
-      await post('https://path/to/api?status=500', {});
+      await get('https://path/to/api?status=500');
     } catch (error) {
-      // $FlowExpectedError: toBeInstanceOf expects classes but ProxiedError is a function
       expect(error).toBeInstanceOf(ProxiedError);
-      expect(error).toHaveProperty('message', 'Status Text');
-      expect(error).toHaveProperty('originStatusCode', 500);
-      expect(error).toHaveProperty(
-        'originUrl',
-        'https://path/to/api?status=500',
-      );
+      expect(error.message).toBe('Status Text');
+      expect(error.extensions).toMatchSnapshot();
     }
   });
 

--- a/src/common/services/__tests__/__snapshots__/HttpRequest.test.js.snap
+++ b/src/common/services/__tests__/__snapshots__/HttpRequest.test.js.snap
@@ -42,6 +42,21 @@ Object {
 }
 `;
 
+exports[`GET request in production throws exception during invalid return status code 1`] = `
+Object {
+  "_proxy": Object {
+    "statusCode": "500",
+    "url": "https://path/to/api?status=500",
+  },
+  "extensions": Object {
+    "proxy": Object {
+      "statusCode": "500",
+      "url": "https://path/to/api?status=500",
+    },
+  },
+}
+`;
+
 exports[`POST request in production adds default content type header 1`] = `
 Object {
   "hint": "this is a mocked response",
@@ -101,5 +116,20 @@ Object {
     "method": "POST",
   },
   "url": "https://path/to/api",
+}
+`;
+
+exports[`POST request in production throws exception during invalid return status code 1`] = `
+Object {
+  "_proxy": Object {
+    "statusCode": "500",
+    "url": "https://path/to/api?status=500",
+  },
+  "extensions": Object {
+    "proxy": Object {
+      "statusCode": "500",
+      "url": "https://path/to/api?status=500",
+    },
+  },
 }
 `;

--- a/src/common/services/errors/ProxiedError.js
+++ b/src/common/services/errors/ProxiedError.js
@@ -1,21 +1,37 @@
 // @flow
 
+type ProxiedErrorValues = {|
+  +statusCode: string,
+  +url: string,
+|};
+
 /**
  * This exception is thrown if origin server does NOT respond with HTTP status code 200.
  */
-function ProxiedError(
-  message: string,
-  originStatusCode: number | string,
-  originUrl: string,
-) {
-  this.name = 'ProxiedError';
-  this.message = message;
-  this.originStatusCode = Number(originStatusCode);
-  this.originUrl = originUrl;
-  this.stack = new Error().stack;
-  return this;
+class ProxiedError extends Error {
+  extensions: {|
+    +_proxy: ProxiedErrorValues,
+    +extensions: {|
+      +proxy: ProxiedErrorValues,
+    |},
+  |};
+
+  constructor(message: string, originStatusCode: string, originUrl: string) {
+    super(message);
+    this.extensions = {
+      _proxy: {
+        // note: this is deprecated and will be removed
+        statusCode: originStatusCode,
+        url: originUrl,
+      },
+      extensions: {
+        proxy: {
+          statusCode: String(originStatusCode),
+          url: originUrl,
+        },
+      },
+    };
+  }
 }
-ProxiedError.prototype = Object.create(Error.prototype);
-ProxiedError.prototype.constructor = ProxiedError;
 
 export { ProxiedError };

--- a/src/common/services/errors/__tests__/ProxiedError.test.js
+++ b/src/common/services/errors/__tests__/ProxiedError.test.js
@@ -14,10 +14,6 @@ it('is throwable', () => {
   }).toThrow('custom message');
 });
 
-it('works with origin status code', () => {
-  expect(error).toHaveProperty('originStatusCode', 123);
-});
-
-it('works with origin URL', () => {
-  expect(error).toHaveProperty('originUrl', 'http://a.b');
+it('adds correct extensions', () => {
+  expect(error.extensions).toMatchSnapshot();
 });

--- a/src/common/services/errors/__tests__/__snapshots__/ProxiedError.test.js.snap
+++ b/src/common/services/errors/__tests__/__snapshots__/ProxiedError.test.js.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`adds correct extensions 1`] = `
+Object {
+  "_proxy": Object {
+    "statusCode": "123",
+    "url": "http://a.b",
+  },
+  "extensions": Object {
+    "proxy": Object {
+      "statusCode": "123",
+      "url": "http://a.b",
+    },
+  },
+}
+`;

--- a/src/graphqlServer.js
+++ b/src/graphqlServer.js
@@ -3,8 +3,8 @@
 import 'dotenv/config';
 import express from 'express';
 import graphqlHTTP from 'express-graphql';
-import cors from 'cors';
 import compression from 'compression';
+import cors from 'cors';
 
 import type { $Request, $Response } from 'express';
 import {
@@ -16,7 +16,6 @@ import {
 import Schema from './Schema';
 import { createContext } from './common/services/GraphqlContext';
 import Logger from './common/services/Logger';
-import { ProxiedError } from './common/services/errors/ProxiedError';
 
 process.on('unhandledRejection', reason => {
   Logger.error(reason);
@@ -54,21 +53,6 @@ function createGraphqlServer(schema, context) {
     pretty: false,
     graphiql: true,
     context: context,
-    formatError(error) {
-      let errorMessage = `${error.name}: ${error.message}`;
-
-      const originalError = error.originalError;
-      if (originalError instanceof ProxiedError) {
-        error._proxy = {
-          statusCode: originalError.originStatusCode,
-          url: originalError.originUrl,
-        };
-        errorMessage += ` ${originalError.originUrl}`;
-      }
-
-      Logger.error(errorMessage);
-      return error;
-    },
     extensions: () => {
       const traceCollector = context._traceCollector;
       if (!traceCollector) return {};

--- a/src/hotel/services/__tests__/BookingComRequest.test.js
+++ b/src/hotel/services/__tests__/BookingComRequest.test.js
@@ -32,19 +32,14 @@ describe('GET request in production', () => {
   });
 
   it('throws exception during invalid return status code', async () => {
-    expect.assertions(4);
+    expect.assertions(3);
 
     try {
       await get('https://path/to/api?status=500');
     } catch (error) {
-      // $FlowExpectedError: toBeInstanceOf expects classes but ProxiedError is a function
       expect(error).toBeInstanceOf(ProxiedError);
-      expect(error).toHaveProperty('message', 'Status Text');
-      expect(error).toHaveProperty('originStatusCode', 500);
-      expect(error).toHaveProperty(
-        'originUrl',
-        'https://path/to/api?status=500',
-      );
+      expect(error.message).toBe('Status Text');
+      expect(error.extensions).toMatchSnapshot();
     }
   });
 });

--- a/src/hotel/services/__tests__/__snapshots__/BookingComRequest.test.js.snap
+++ b/src/hotel/services/__tests__/__snapshots__/BookingComRequest.test.js.snap
@@ -12,3 +12,18 @@ Object {
   "url": "https://path/to/api",
 }
 `;
+
+exports[`GET request in production throws exception during invalid return status code 1`] = `
+Object {
+  "_proxy": Object {
+    "statusCode": "500",
+    "url": "https://path/to/api?status=500",
+  },
+  "extensions": Object {
+    "proxy": Object {
+      "statusCode": "500",
+      "url": "https://path/to/api?status=500",
+    },
+  },
+}
+`;


### PR DESCRIPTION
Current error object looks like this:

```json
{
  "_proxy": {
    "statusCode": "123",
    "url": "http://a.b"
  },
  "extensions": {
    "proxy": {
      "statusCode": "123",
      "url": "http://a.b"
    }
  },
  "message": "custom message",
  "locations": [
    {
      "line": 4,
      "column": 5
    }
  ],
  "path": [
    "currency",
    "format"
  ]
}
```

It should be backward compatible. See: http://facebook.github.io/graphql/draft/#sec-Errors

Related issue: https://github.com/kiwicom/graphql/issues/212