### PR TITLE
use singleBooking instead of booking

### DIFF
--- a/scripts/graphql-schema-snapshot.json
+++ b/scripts/graphql-schema-snapshot.json
@@ -1233,15 +1233,15 @@
                   "name": null,
                   "ofType": {
                     "kind": "SCALAR",
-                    "name": "ID",
+                    "name": "Int",
                     "ofType": null
                   }
                 },
                 "defaultValue": null
               },
               {
-                "name": "simpleToken",
-                "description": "Simple Token that lets you fetch a unique booking.",
+                "name": "authToken",
+                "description": "Simple auth token that lets you fetch a unique booking.",
                 "type": {
                   "kind": "NON_NULL",
                   "name": null,
@@ -1255,8 +1255,8 @@
               }
             ],
             "type": {
-              "kind": "OBJECT",
-              "name": "Booking",
+              "kind": "INTERFACE",
+              "name": "BookingInterface",
               "ofType": null
             },
             "isDeprecated": false,

--- a/src/booking/dataloaders/SingleBooking.js
+++ b/src/booking/dataloaders/SingleBooking.js
@@ -3,12 +3,12 @@
 import DataLoader from 'dataloader';
 import stringify from 'json-stable-stringify';
 import { get } from '../../common/services/HttpRequest';
-import Config from '../../../config/application';
 import { sanitizeDetail } from './ApiSanitizer';
-import type { Booking } from '../Booking';
+import { queryWithParameters } from '../../../config/application';
+import type { BookingInterfaceData } from '../types/outputs/BookingInterface';
 
 export type Args = {|
-  +simpleToken: string,
+  +authToken: string,
   +id: number,
 |};
 
@@ -24,13 +24,21 @@ export default function createSingleBookingLoader() {
 async function batchLoad(
   bookings: $ReadOnlyArray<Args>,
 ): Promise<Array<Object>> {
-  const promises = bookings.map(({ id, simpleToken }: Args) =>
-    fetchFAQ(id, simpleToken),
+  const promises = bookings.map(({ id, authToken }: Args) =>
+    fetch(id, authToken),
   );
   const responses = await Promise.all(promises);
   return responses.map(result => sanitizeDetail(result));
 }
 
-async function fetchFAQ(bid: number, simpleToken: string): Promise<Booking> {
-  return await get(Config.restApiEndpoint.singleBooking(bid, simpleToken));
+async function fetch(
+  bid: number,
+  authToken: string,
+): Promise<BookingInterfaceData> {
+  return await get(
+    queryWithParameters(
+      `https://booking-api.skypicker.com/api/v0.1/users/self/bookings/${bid}`,
+      { simple_token: authToken },
+    ),
+  );
 }

--- a/src/booking/queries/SingleBooking.js
+++ b/src/booking/queries/SingleBooking.js
@@ -1,31 +1,31 @@
 // @flow
 
-import { GraphQLID, GraphQLNonNull, GraphQLString } from 'graphql';
+import { GraphQLInt, GraphQLNonNull, GraphQLString } from 'graphql';
 
-import GraphQLBooking from '../types/outputs/Booking';
+import GraphQLBookingInterface from '../types/outputs/BookingInterface';
 import type { GraphqlContextType } from '../../common/services/GraphqlContext';
-import type { BookingsItem } from '../Booking';
+import type { BookingInterfaceData } from '../types/outputs/BookingInterface';
 
 export default {
-  type: GraphQLBooking,
+  type: GraphQLBookingInterface,
   description: 'Find booking by its id and its simple access token.',
   args: {
     id: {
-      type: new GraphQLNonNull(GraphQLID),
+      type: new GraphQLNonNull(GraphQLInt),
       description:
         'Database ID (human readable ID) of the booking. ' +
         'You should use "node" query if you want to use opaque ID.',
     },
-    simpleToken: {
+    authToken: {
       type: new GraphQLNonNull(GraphQLString),
-      description: 'Simple Token that lets you fetch a unique booking.',
+      description: 'Simple auth token that lets you fetch a unique booking.',
     },
   },
   resolve: async (
     ancestor: mixed,
-    { id, simpleToken }: Object,
+    { id, authToken }: Object,
     { dataLoader }: GraphqlContextType,
-  ): Promise<BookingsItem> => {
-    return dataLoader.singleBooking.load({ id, simpleToken });
+  ): Promise<BookingInterfaceData> => {
+    return dataLoader.singleBooking.load({ id, authToken });
   },
 };

--- a/src/booking/queries/__tests__/SingleBooking.test.js
+++ b/src/booking/queries/__tests__/SingleBooking.test.js
@@ -15,8 +15,8 @@ describe('singleBooking query', () => {
     ).replyWithData(Booking2707251);
 
     const query = `
-    query($id: ID!, $simpleToken: String!) {
-      singleBooking(id: $id, simpleToken: $simpleToken) {
+    query($id: Int!, $authToken: String!) {
+      singleBooking(id: $id, authToken: $authToken) {
         id
         price{
           amount
@@ -26,18 +26,19 @@ describe('singleBooking query', () => {
         destinationImageUrl
         directAccessURL
         passengerCount
-        oneWay {
-          bookingDate
-          trip {
-            duration
-          }
+        passengers {
+          nationality
+        }
+        bookingDate
+        assets{
+          ticketUrl
         }
       }
     }`;
     expect(
       await graphql(query, {
         id: 2707251,
-        simpleToken: 'b834267c-def7-4dc8-1661-a5283d25d5e9',
+        authToken: 'b834267c-def7-4dc8-1661-a5283d25d5e9',
       }),
     ).toMatchSnapshot();
   });

--- a/src/booking/queries/__tests__/__snapshots__/SingleBooking.test.js.snap
+++ b/src/booking/queries/__tests__/__snapshots__/SingleBooking.test.js.snap
@@ -4,17 +4,22 @@ exports[`singleBooking query should return valid fields 1`] = `
 Object {
   "data": Object {
     "singleBooking": Object {
+      "assets": Object {
+        "ticketUrl": "https://skypicker-mailing.s3.amazonaws.com/2707/1490859068_E-ticket_passenger_and_1_more_e826fc3275a65a5db8808279d8fc7f8f.pdf?v=1490859069",
+      },
       "bookingDate": "2017-03-30",
       "destinationImageUrl": "https://images.kiwi.com/photos/600x600/paris_fr.grayscale.jpg",
       "directAccessURL": "https://kiwi.com/content/manage/2707251/b206db64-718f-4608-babb-0b8abe6e1b9d",
-      "id": "Qm9va2luZzoyNzA3MjUx",
-      "oneWay": Object {
-        "bookingDate": "2017-03-30",
-        "trip": Object {
-          "duration": 80,
-        },
-      },
+      "id": "Qm9va2luZ09uZVdheToyNzA3MjUx",
       "passengerCount": 2,
+      "passengers": Array [
+        Object {
+          "nationality": "us",
+        },
+        Object {
+          "nationality": "us",
+        },
+      ],
       "price": Object {
         "amount": 74.61,
         "currency": "USD",

--- a/src/booking/types/outputs/BookingInterface.js
+++ b/src/booking/types/outputs/BookingInterface.js
@@ -71,11 +71,14 @@ export const commonFields = {
   allowedBaggage: {
     type: GraphQLAllowedBaggage,
     resolve: async (
-      { id }: BookingInterfaceData,
+      { id, authToken }: BookingInterfaceData,
       params: Object,
       { dataLoader }: GraphqlContextType,
     ): Promise<AllowedBaggage> => {
-      const { allowedBaggage } = await dataLoader.booking.load(id);
+      const { allowedBaggage } = await dataLoader.singleBooking.load({
+        id,
+        authToken,
+      });
       return allowedBaggage;
     },
   },
@@ -84,11 +87,14 @@ export const commonFields = {
     type: GraphQLBookingAssets,
     description: 'Static assets related to this booking.',
     resolve: async (
-      { id }: BookingInterfaceData,
+      { id, authToken }: BookingInterfaceData,
       params: Object,
       { dataLoader }: GraphqlContextType,
     ): Promise<BookingAssets> => {
-      const { assets } = await dataLoader.booking.load(id);
+      const { assets } = await dataLoader.singleBooking.load({
+        id,
+        authToken,
+      });
       return assets;
     },
   },
@@ -96,11 +102,14 @@ export const commonFields = {
   passengers: {
     type: new GraphQLList(Passenger),
     resolve: async (
-      { id }: BookingInterfaceData,
+      { id, authToken }: BookingInterfaceData,
       args: Object,
       { dataLoader }: GraphqlContextType,
     ) => {
-      const { passengers } = await dataLoader.booking.load(id);
+      const { passengers } = await dataLoader.singleBooking.load({
+        id,
+        authToken,
+      });
       return passengers;
     },
   },
@@ -196,11 +205,14 @@ export const commonFields = {
   bookedServices: {
     type: new GraphQLList(GraphQLBookedServices),
     resolve: async (
-      { id }: BookingInterfaceData,
+      { id, authToken }: BookingInterfaceData,
       args: Object,
       { dataLoader }: GraphqlContextType,
     ) => {
-      const { bookedServices } = await dataLoader.booking.load(id);
+      const { bookedServices } = await dataLoader.singleBooking.load({
+        id,
+        authToken,
+      });
       return bookedServices;
     },
   },
@@ -208,11 +220,14 @@ export const commonFields = {
   contactDetails: {
     type: GraphQLContactDetails,
     resolve: async (
-      { id }: BookingInterfaceData,
+      { id, authToken }: BookingInterfaceData,
       args: Object,
       { dataLoader }: GraphqlContextType,
     ) => {
-      const { contactDetails } = await dataLoader.booking.load(id);
+      const { contactDetails } = await dataLoader.singleBooking.load({
+        id,
+        authToken,
+      });
       return contactDetails;
     },
   },
@@ -241,11 +256,14 @@ export const commonFields = {
   onlineCheckinIsAvailable: {
     type: GraphQLBoolean,
     resolve: async (
-      { id }: BookingInterfaceData,
+      { id, authToken }: BookingInterfaceData,
       args: Object,
       { dataLoader }: GraphqlContextType,
     ) => {
-      const { onlineCheckinIsAvailable } = await dataLoader.booking.load(id);
+      const { onlineCheckinIsAvailable } = await dataLoader.singleBooking.load({
+        id,
+        authToken,
+      });
       return onlineCheckinIsAvailable;
     },
   },


### PR DESCRIPTION
This is BC (no one is using this query), changed param `simpleToken` to `authToken` and used correct type `Int` instead of `ID`

Changing `booking` to `singleBooking` was needed because `singleBookingQuery` was failing loading fields that were using `booking` for example `assets`, `passengers`, `contactDetails`...

References https://github.com/kiwicom/smart-faq/issues/489